### PR TITLE
Add configuration option to ignore stdin processing

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -37,7 +37,7 @@ module Mailman
         require rails_env
       end
 
-      if $stdin.fcntl(Fcntl::F_GETFL, 0) == 0 # we have stdin
+      if !Mailman.config.ignore_stdin && $stdin.fcntl(Fcntl::F_GETFL, 0) == 0 # we have stdin
         Mailman.logger.debug "Processing message from STDIN."
         @processor.process($stdin.read)
       elsif Mailman.config.pop3

--- a/lib/mailman/configuration.rb
+++ b/lib/mailman/configuration.rb
@@ -18,6 +18,10 @@ module Mailman
     #   rails environment loading
     attr_accessor :rails_root
 
+    # @return [boolean] whether or not to ignore stdin.  Setting this to true 
+    #   stops Mailman from entering stdin processing mode.
+    attr_accessor :ignore_stdin
+    
     def logger
       @logger ||= Logger.new(STDOUT)
     end

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -65,6 +65,24 @@ describe Mailman::Application do
     @app.run.should be_true
     $stdin.string = nil
   end
+  
+  describe "(when config.ignore_stdin)" do
+    before do
+      Mailman.config.ignore_stdin = true
+    end
+      
+    it "should not accept a message from STDIN" do
+      mailman_app {
+        from('jamis@37signals.com') do
+          true
+        end
+      }
+
+      $stdin.string = fixture('example02')
+      @app.run.should be_false
+      $stdin.string = nil
+    end
+  end
 
   it 'should poll a POP3 server, and process messsages' do
     config.pop3 = { :server => 'example.com',

--- a/spec/mailman/configuration_spec.rb
+++ b/spec/mailman/configuration_spec.rb
@@ -46,5 +46,13 @@ describe Mailman::Configuration do
     config.rails_root = 'test-app'
     config.rails_root.should == 'test-app'
   end
-
+  
+  it 'should default to not ignoring stdin' do
+    config.ignore_stdin.should == nil
+  end
+  
+  it 'should store ignore_stdin setting' do
+    config.ignore_stdin = true
+    config.ignore_stdin.should == true
+  end
 end


### PR DESCRIPTION
Hi There,

Thanks for mailmain, it's just geat.

I;ve been having trouble daemonizing mailman, and it's to do with the stdin processing mode.  Basically, maimain always detects stdin when I'm running it as a daemon.

This patch simply adds a :ignore_stdin configuration option, and a couple of specs.

Cheers,
Ian
