### PR TITLE
Receiver as module

### DIFF
--- a/lib/mailman/receiver.rb
+++ b/lib/mailman/receiver.rb
@@ -1,5 +1,5 @@
 module Mailman
-  class Receiver
+  module Receiver
 
     autoload :POP3, 'mailman/receiver/pop3'
 

--- a/lib/mailman/receiver/pop3.rb
+++ b/lib/mailman/receiver/pop3.rb
@@ -1,7 +1,7 @@
 require 'net/pop'
 
 module Mailman
-  class Receiver
+  module Receiver
     # Receives messages using POP3, and passes them to a {MessageProcessor}.
     class POP3
 


### PR DESCRIPTION
I don't know if it's deliberate, but `Receiver` seems to be merely a placeholder for receiver implementations, and should probably be a module then.

Perhaps rename it `Receivers` though?
