### PR TITLE
Graceful Handling of POP3 connection errors

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -53,10 +53,14 @@ module Mailman
 
         connection = Receiver::POP3.new(options)
         loop do
-          Mailman.logger.debug "Checking POP3 server for messages..."
-          connection.connect
-          connection.get_messages
-          connection.disconnect
+          begin
+            connection.connect
+            connection.get_messages
+            connection.disconnect
+          rescue SystemCallError => e
+            Mailman.logger.error e.message
+          end
+
           break if !polling
           sleep Mailman.config.poll_interval
         end

--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'maildir', '>= 0.5.0'
   s.add_dependency 'i18n', '>= 0.4.1' # fix for mail/activesupport-3 dependency issue
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '1.3.2'
+  s.add_development_dependency 'mocha'
 
   s.files        = Dir.glob('{bin,lib,examples}/**/*') + %w(LICENSE README.md USER_GUIDE.md)
   s.require_path = 'lib'

--- a/spec/mailman/receiver/pop3_spec.rb
+++ b/spec/mailman/receiver/pop3_spec.rb
@@ -16,7 +16,7 @@ describe Mailman::Receiver::POP3 do
     it 'should connect to a POP3 server' do
       @receiver.connect.should be_true
     end
-
+    
     it 'should disconnect from a POP3 server' do
       @receiver.connect
       @receiver.disconnect.should be_true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'mailman'
 require 'spec'
 require 'spec/autorun'
 require 'pop3_mock'
+require 'mocha'
 
 unless defined?(SPEC_ROOT)
   SPEC_ROOT = File.join(File.dirname(__FILE__))
@@ -53,6 +54,7 @@ end
 
 Spec::Runner.configure do |config|
   config.include Mailman::SpecHelpers
+  config.mock_with :mocha
 end
 
 


### PR DESCRIPTION
I've noticed that long-running Mailman instances crash if Net::POP3 raises connection errors (ie, no route to host, timeout, etc). Rather than letting it crash, I've added a simple handler for those instances.

I've also quietened the POP3 handler down somewhat.

Note: I've added Mocha as a development dependency.
