### PR TITLE
Only load FSSM and Maildir when necessary

### DIFF
--- a/lib/mailman.rb
+++ b/lib/mailman.rb
@@ -5,9 +5,6 @@ require 'active_support'
 require 'active_support/core_ext/string/inflections'
 require 'active_support/core_ext/hash/indifferent_access'
 
-require 'maildir'
-require 'fssm'
-
 require 'mailman/version'
 
 module Mailman

--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -66,6 +66,9 @@ module Mailman
         end
 
       elsif Mailman.config.maildir
+        require 'maildir'
+        require 'fssm'
+
         Mailman.logger.info "Maildir receiver enabled (#{Mailman.config.maildir})."
         maildir = Maildir.new(Mailman.config.maildir)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require 'spec'
 require 'spec/autorun'
 require 'pop3_mock'
 require 'mocha'
+require 'maildir'
 
 unless defined?(SPEC_ROOT)
   SPEC_ROOT = File.join(File.dirname(__FILE__))


### PR DESCRIPTION
This prevents the obnoxious:

FSSM -> An optimized backend is available for this platform!
FSSM ->     gem install rb-fsevent

messages, especially as I am using POP3 and don't want this code loaded anyways!
