### PR TITLE
fix spec failure after using mocha instead of rspec-expectations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,18 +11,18 @@ PATH
 GEM
   remote: http://rubygems.org/
   specs:
-    activesupport (3.0.0)
-    fssm (0.1.4)
-    i18n (0.4.1)
-    mail (2.2.6.1)
-      activesupport (>= 2.3.6)
-      mime-types
-      treetop (>= 1.4.5)
-    maildir (0.6.0)
+    activesupport (3.0.9)
+    fssm (0.2.7)
+    i18n (0.6.0)
+    mail (2.3.0)
+      i18n (>= 0.4.0)
+      mime-types (~> 1.16)
+      treetop (~> 1.4.8)
+    maildir (1.0.1)
     mime-types (1.16)
     polyglot (0.3.1)
-    rspec (1.3.0)
-    treetop (1.4.8)
+    rspec (1.3.2)
+    treetop (1.4.9)
       polyglot (>= 0.3.1)
 
 PLATFORMS
@@ -30,10 +30,5 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (>= 2.3.4)
-  fssm (>= 0.1.4)
-  i18n (>= 0.4.1)
-  mail (>= 2.0.3)
-  maildir (>= 0.5.0)
   mailman!
-  rspec
+  rspec (= 1.3.2)

--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'i18n', '>= 0.4.1' # fix for mail/activesupport-3 dependency issue
 
   s.add_development_dependency 'rspec', '1.3.2'
-  s.add_development_dependency 'mocha'
 
   s.files        = Dir.glob('{bin,lib,examples}/**/*') + %w(LICENSE README.md USER_GUIDE.md)
   s.require_path = 'lib'

--- a/spec/mailman/receiver/pop3_spec.rb
+++ b/spec/mailman/receiver/pop3_spec.rb
@@ -16,7 +16,7 @@ describe Mailman::Receiver::POP3 do
     it 'should connect to a POP3 server' do
       @receiver.connect.should be_true
     end
-    
+
     it 'should disconnect from a POP3 server' do
       @receiver.connect
       @receiver.disconnect.should be_true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ require 'mailman'
 require 'spec'
 require 'spec/autorun'
 require 'pop3_mock'
-require 'mocha'
 require 'maildir'
 
 unless defined?(SPEC_ROOT)
@@ -55,7 +54,6 @@ end
 
 Spec::Runner.configure do |config|
   config.include Mailman::SpecHelpers
-  config.mock_with :mocha
 end
 
 


### PR DESCRIPTION
After commit https://github.com/titanous/mailman/commit/17f08eca2376a363e15197761675d07de97a067a All spec doesn't works with the mocha integration.

This commit avoid using mocha and fix all spec now.
