### PR TITLE
process new messages in the maildir upon launch

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -72,6 +72,7 @@ module Mailman
 
         Mailman.logger.info "Maildir receiver enabled (#{Mailman.config.maildir})."
         @maildir = Maildir.new(Mailman.config.maildir)
+        process_maildir
 
         Mailman.logger.debug "Monitoring the Maildir for new messages..."
         Listen.to File.join(Mailman.config.maildir, 'new') do |modified, added, removed|


### PR DESCRIPTION
The [USER_GUIDE](https://github.com/titanous/mailman/blob/master/USER_GUIDE.md) claims that new messages are processed on launch before watching the maildir for new files, however that isn't actually the case. This adds that feature. (with tests)
