### PR TITLE
IMAP Receiver Crashes, Can't Set Port, Can't Set Folder, Can't Set SSL

### DIFF
--- a/lib/mailman/receiver/imap.rb
+++ b/lib/mailman/receiver/imap.rb
@@ -13,8 +13,10 @@ module Mailman
       #   messages to
       # @option options [String] :server the server to connect to
       # @option options [Integer] :port the port to connect to
+      # @option options [Boolean] :ssl whether or not to use ssl
       # @option options [String] :username the username to authenticate with
       # @option options [String] :password the password to authenticate with
+      # @option options [String] :folder the mail folder to search
       def initialize(options)
         @processor = options[:processor]
         @server    = options[:server]
@@ -22,15 +24,17 @@ module Mailman
         @password  = options[:password]
         @filter    = options[:filter] || ['NEW']
         @port      = options[:port] || 143
+        @ssl       = options[:ssl] || false
+        @folder    = options[:folder] || "INBOX"
       end
 
       # Connects to the IMAP server.
       def connect
         if @connection.nil? or @connection.disconnected?
-          @connection = Net::IMAP.new(@server, @port)
+          @connection = Net::IMAP.new(@server, {:port => @port, :ssl => @ssl})
           @connection.login(@username, @password)
         end
-        @connection.select("INBOX")
+        @connection.select(@folder)
       end
 
       # Disconnects from the IMAP server.


### PR DESCRIPTION
In this pull request are some major improvements to the IMAP code. 

The old version would crash on the second poll, since a connection was opened, but each poll calls 'connect', where it the IMAP code would reattempt login. In this version, I simply check if the connection is already open.

The second parameter to Net::IMAP#new should be a hash, rather than Fixnum. This allows setting the port as well as enabling SSL so that a user could use port 993.

Added an option for setting a folder other than INBOX.

The old version of this code called 'examine' rather than 'select' on a folder. The difference is that 'examine' opens the folder in read-only mode, which would raise an exception when the 'store' method was called to delete the read message.
