### PR TITLE
fix ruby 1.8.7 compat with imap receiver

### DIFF
--- a/lib/mailman/receiver/imap.rb
+++ b/lib/mailman/receiver/imap.rb
@@ -31,7 +31,7 @@ module Mailman
       # Connects to the IMAP server.
       def connect
         if @connection.nil? or @connection.disconnected?
-          @connection = Net::IMAP.new(@server, {:port => @port, :ssl => @ssl})
+          @connection = Net::IMAP.new(@server, @port, @ssl)
           @connection.login(@username, @password)
         end
         @connection.select(@folder)


### PR DESCRIPTION
the hash-as-second-arg only works in 1.9.x, passing port and ssl as the
2nd and 3rd params works in both versions of ruby.
