### PR TITLE
Non-match on multipart mail body should return nil

### DIFF
--- a/lib/mailman/route/conditions.rb
+++ b/lib/mailman/route/conditions.rb
@@ -38,11 +38,11 @@ module Mailman
     class BodyCondition < Condition
       def match(message)
         if message.multipart?
+          result = nil
           message.parts.each do |part|
-            if result = @matcher.match(part.decoded)
-              return result
-            end
+            break if result = @matcher.match(part.decoded)
           end
+          return result
         else
           @matcher.match(message.body.decoded)
         end

--- a/spec/mailman/route/conditions_spec.rb
+++ b/spec/mailman/route/conditions_spec.rb
@@ -66,6 +66,14 @@ describe Mailman::Route::BodyCondition do
     Mailman::Route.new.body('test').conditions[0].class.should == Mailman::Route::BodyCondition
   end
 
+  it 'returns nil for a non-matching body of a multipart message' do
+    Mailman::Route::BodyCondition.new('foo').match(multipart_message).should be_nil
+  end
+
+  it 'matches on the body of a multipart message' do
+    Mailman::Route::BodyCondition.new('plain').match(multipart_message).should == [{}, []]
+  end
+
 end
 
 describe Mailman::Route::CcCondition do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,24 @@ module Mailman::SpecHelpers
     Mail.new("To: test@example.com\r\nFrom: chunky@bacon.com\r\nCC: testing@example.com\r\nSubject: Hello!\r\n\r\nemail message\r\n")
   end
 
+  def multipart_message
+    mail = Mail.new do
+      to   'test@example.com'
+      from 'chunky@bacon.com'
+      subject 'I am a multipart message'
+
+      text_part do
+        body 'This is plain text'
+      end
+
+      html_part do
+        content_type 'text/html; charset=UTF-8'
+        body '<h1>This is HTML</h1>'
+      end
+    end
+
+  end
+
   def mailman_app(&block)
     @app = Mailman::Application.new(&block)
   end


### PR DESCRIPTION
This fixes a bug with matching the body of a multipart mail message.
When the body of a multipart mail message was not matched, it defaulted to
the result of the 'message.parts.each' iteration which is the
array of parts - now it will return nil as expected.
