### PR TITLE
Change homepage to github

### DIFF
--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ['Jonathan Rudenberg']
   s.email       = ['jonathan@titanous.com']
-  s.homepage    = 'http://mailmanrb.com'
+  s.homepage    = 'https://github.com/titanous/mailman'
   s.summary     = 'A incoming email processing microframework'
   s.description = 'Mailman makes it easy to process incoming emails with a simple routing DSL'
   s.signing_key   = File.expand_path('~/.gem_keys/gem-private_key.pem')


### PR DESCRIPTION
As http://mailmanrb.com (no longer?) exists, change this to github.com.

So the link on the rubygems page should lead to this repository.
