### PR TITLE
Adding configurable open/read timeouts to POP3 receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.1 (Unreleased)
+
+Features
+
+  - POP3: Configurable open_timeout and read_timeout values
+
+
 ## 0.6.0 (January 12, 2013)
 
 Features

--- a/lib/mailman/receiver/pop3.rb
+++ b/lib/mailman/receiver/pop3.rb
@@ -22,6 +22,8 @@ module Mailman
         @password = options[:password]
         @connection = Net::POP3.new(options[:server], options[:port])
         @connection.enable_ssl(OpenSSL::SSL::VERIFY_NONE) if options[:ssl]
+        @connection.open_timeout = options[:open_timeout] if options[:open_timeout]
+        @connection.read_timeout = options[:read_timeout] if options[:read_timeout]
       end
 
       # Connects to the POP3 server.

--- a/spec/mailman/receiver/pop3_spec.rb
+++ b/spec/mailman/receiver/pop3_spec.rb
@@ -7,7 +7,9 @@ describe Mailman::Receiver::POP3 do
     @receiver_options = { :username  => 'user',
                           :password  => 'pass',
                           :server    =>  'example.com',
-                          :processor => @processor }
+                          :processor => @processor,
+                          :open_timeout => 30,
+                          :read_timeout => 60 }
     @receiver = Mailman::Receiver::POP3.new(@receiver_options)
   end
 

--- a/spec/support/pop3_mock.rb
+++ b/spec/support/pop3_mock.rb
@@ -85,6 +85,14 @@ class MockPOP3
     end
     @@popmails = []
   end
+
+  def open_timeout=(seconds)
+    @@open_timeout = seconds
+  end
+
+  def read_timeout=(seconds)
+    @@read_timeout = seconds
+  end
 end
 
 require 'net/pop'


### PR DESCRIPTION
See ticket https://github.com/titanous/mailman/issues/75 for more information about why this is needed.
