### PR TITLE
Command line interface and Capistrano recipe for Mailman

### DIFF
--- a/bin/mailman
+++ b/bin/mailman
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require 'mailman/cli'
+require 'optparse'
+
+$:.<< '.'
+
+options = {}
+
+ARGV.options do |opts|
+  opts.on('-c', '--config=val', String) { |config_file| options[:config_file] = config_file }
+  opts.on('-p', '--pidfile=val', String) { |pid_file| options[:pid_file] = pid_file }
+  opts.on('-e', '--environment=val', String) { |environment| options[:environment] = environment }
+
+  opts.parse!
+end
+
+begin
+  Mailman::CLI.new(options).run
+rescue => e
+  STDERR.puts e
+  STDERR.puts e.backtrace.join("\n")
+
+  exit 1
+end

--- a/lib/mailman/cli.rb
+++ b/lib/mailman/cli.rb
@@ -1,0 +1,39 @@
+require 'mailman'
+
+module Mailman
+  class CLI
+    class ConfigNotDefined < StandardError; end
+
+    def initialize(options = {})
+      @config_file = options[:config_file]
+      @pid_file = options[:pid_file]
+      @environment = options[:environment]
+    end
+
+    def run
+      set_environment
+      record_pid_file
+      load_config
+    end
+
+    def set_environment
+      ENV['RACK_ENV'] = ENV['RAILS_ENV'] = @environment
+    end
+
+    def load_config
+      if @config_file
+        require @config_file
+      else
+        raise ConfigNotDefined.new
+      end
+    end
+
+    def record_pid_file
+      if @pid_file
+        File.open(@pid_file, 'w') do |f|
+          f.puts Process.pid
+        end
+      end
+    end
+  end
+end

--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
 
   s.files        = Dir.glob('{bin,lib,examples}/**/*') + %w(LICENSE README.md USER_GUIDE.md CHANGELOG.md)
   s.require_path = 'lib'
+  s.executables  = ['mailman']
 end


### PR DESCRIPTION
Hello, I've added an executable file and conventions/configurations for deploying Mailman in production environment. Here are what this PR adds:
## Executable file

```
`mailman -c [config file] -p [pid file] -e [environment]`
```

Config file contains configurations and instructions for Mailman, like `mailman_app.rb` example in `USER_GUIDE.md` does. It should be provided in order to execute `mailman`. Pid file and environment parameters are optional.
## Capistrano recipe

If you use Capistrano to deploy your application, just add

```
require 'mailman/capistrano`
```

in your `deploy.rb`. It uses `"#{current_path}/config/mailman.rb"` for config file, `"#{current_path}tmp/pids/mailman.pid"` for pid file as default.
