### PR TITLE
Fix wrong arguments given to Net::IMAP constructor, it should take 2 arg...

### DIFF
--- a/lib/mailman/receiver/imap.rb
+++ b/lib/mailman/receiver/imap.rb
@@ -36,7 +36,7 @@ module Mailman
       # Connects to the IMAP server.
       def connect
         if @connection.nil? or @connection.disconnected?
-          @connection = Net::IMAP.new(@server, @port, @ssl)
+          @connection = Net::IMAP.new(@server, port: @port, ssl: @ssl)
           @connection.login(@username, @password)
         end
         @connection.select(@folder)


### PR DESCRIPTION
...uments host and options.

ssl option can be hash now, in this case Net::IMAP pass it to OpenSSL::SSL::SSLContext#set_params, so we can pass options like:

Mailman.config.imap = {
  ssl: { verify_mode: OpenSSL::SSL::VERIFY_NONE },
  ...
}
