### PR TITLE
Always disconnect in polling loop (even if exception was raised)

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -131,9 +131,10 @@ module Mailman
         begin
           connection.connect
           connection.get_messages
-          connection.disconnect
         rescue SystemCallError => e
           Mailman.logger.error e.message
+        ensure
+          connection.disconnect
         end
 
         break unless polling?


### PR DESCRIPTION
Always disconnect in polling loop (even if exception was raised) in order to prevent crashes in underlying POP3 receiver which does not handle multiple connections well.

Fixes #81
