### PR TITLE
Prevent mailman from exiting prematurely if `config.watch_maildir` is true

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -105,6 +105,7 @@ module Mailman
 
           @listener = Listen.to(File.join(@maildir.path, 'new'), :relative_paths => true).change(&callback)
           @listener.start!
+          sleep
         end
       end
     end


### PR DESCRIPTION
The maildir functionality seems to work as expected once this has been changed.
