### PR TITLE
update Listen message send to use new Listen 2.2.0 API

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -103,8 +103,9 @@ module Mailman
             end
           end
 
-          @listener = Listen.to(File.join(@maildir.path, 'new'), :relative_paths => true).change(&callback)
-          @listener.start!
+          @listener = Listen::Listener.new(File.join(@maildir.path, 'new'), :relative_paths => true, &callback)
+          @listener.start
+          sleep
         end
       end
     end


### PR DESCRIPTION
This pull request updates Mailman to use the latest version of Listen which today is '2.2.0'.  Listen 2.2.0 has a new API that breaks Mailman. Mailman's gemspec specifies a dependency on Listen with '~> 1.3.1' which to my knowledge means >= 1.3.1 and < 2.0, however Listen 2.2.0 was installed for me with Mailman so I chose to deal with it.  
