### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 
 matrix:
   allow_failures:
-    - rvm:
-      - ruby-head
-      - jruby-head
-      - rbx-19mode
+    - rvm: ruby-head
+    - rvm: jruby-19mode
+    - rvm: jruby-head
+    - rvm: rbx-19mode


### PR DESCRIPTION
this should make travis actually allow fails on jruby and rubinius
