### PR TITLE
allow use with 2.x versions of listen > 2.2 

### DIFF
--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'mail', '>= 2.0.3'
   s.add_dependency 'activesupport', '>= 2.3.4'
-  s.add_dependency 'listen', '~> 2.2.0'
+  s.add_dependency 'listen', '~> 2.2'
   s.add_dependency 'maildir', '>= 0.5.0'
   s.add_dependency 'i18n', '>= 0.4.1' # fix for mail/activesupport-3 dependency issue
 


### PR DESCRIPTION
 All tests pass w/ listen 2.7.7, ruby 2.1.2.

mailman currently forces v 2.2.0 of the listen gem.  We've had significant problems with that version when using it as a component of guard; later 2.x versions fix our problems.
