### PR TITLE
pop3.rb: enable ssl certificate validation by default

### DIFF
--- a/lib/mailman/receiver/pop3.rb
+++ b/lib/mailman/receiver/pop3.rb
@@ -21,7 +21,7 @@ module Mailman
         @username = options[:username]
         @password = options[:password]
         @connection = Net::POP3.new(options[:server], options[:port])
-        @connection.enable_ssl(OpenSSL::SSL::VERIFY_NONE) if options[:ssl]
+        @connection.enable_ssl if options[:ssl]
         @connection.open_timeout = options[:open_timeout] if options[:open_timeout]
         @connection.read_timeout = options[:read_timeout] if options[:read_timeout]
       end


### PR DESCRIPTION
Ignoring certificates is dangerous by default is a security hole!
