### PR TITLE
Temporary fix for #116

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--require spec_helper
+--format progress
+-cfd

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem 'rake'
 gem 'jruby-openssl', :platforms => :jruby
+gem 'mail', :git => 'git://github.com/mikel/mail.git'

--- a/Rakefile
+++ b/Rakefile
@@ -40,4 +40,5 @@ task :gemspec do
 end
 
 task :package => :gemspec
-task :default => :spec
+task :test    => :spec
+task :default => :test

--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'mailman'
 
-  s.add_dependency 'mail', '>= 2.0.3'
+  s.add_dependency 'mail', '~>2.0', '>= 2.0.3'
   s.add_dependency 'activesupport', '>= 2.3.4'
   s.add_dependency 'listen', '~> 2.2'
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,4 +86,3 @@ RSpec.configure do |config|
     FileUtils.rm File.join(SPEC_ROOT, 'mailman-log.log') rescue nil
   end
 end
-


### PR DESCRIPTION
* Marks the offending test as pending in RBX (with description of issue in code along with `FIXME` tag)
* *Temporary measure*: Forces `mail` gem to latest from git to ensure [this bug](https://github.com/mikel/mail/pull/782) is addressed.
* Adds timeout to threading test scenario (this isn't effectual in RBX, but it seems like it should be present when there are `sleep`s about!)
* Adds `rake test`