### PR TITLE
Allow newer versions of the listen gem

### DIFF
--- a/mailman.gemspec
+++ b/mailman.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'mail', '~>2.0', '>= 2.0.3'
   s.add_dependency 'activesupport', '>= 2.3.4'
-  s.add_dependency 'listen', '~> 2.2'
+  s.add_dependency 'listen', '>= 2.2'
   if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.0.0')
     s.add_dependency 'maildir', '>= 0.5.0', '< 2.1.0'
   else


### PR DESCRIPTION
I allowed new versions of listen. All tests are successful and my app, which uses mailman, works correctly.