### PR TITLE
refer to Rails as a root level class instead of a module within mailman

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -58,7 +58,7 @@ module Mailman
 
       if config.rails_root
         rails_env = File.join(config.rails_root, 'config', 'environment.rb')
-        if File.exist?(rails_env) && !(defined?(Rails) && Rails.env)
+        if File.exist?(rails_env) && !(defined?(::Rails) && ::Rails.env)
           Mailman.logger.info "Rails root found in #{config.rails_root}, requiring environment..."
           require rails_env
         end


### PR DESCRIPTION
I want to run mailman within a rake task. The reference to Rails.env crashed in my environment (ruby 2.2) with: "NoMethodError: undefined method `env' for Mailman::Rails:Module"