### PR TITLE
Move seen messages

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -237,7 +237,9 @@ Mailman.config.imap = {
   # Use starttls instead of ssl (do not specify both)
   #starttls: true,
   username: 'foo@somedomain.com',
-  password: 'totallyunsecuredpassword'
+  password: 'totallyunsecuredpassword',
+  move_seen: false, #if you want to move seen messages to another folder
+  seen_folder: "PROCESSING"
 }
 
 ```

--- a/spec/mailman/receiver/imap_spec.rb
+++ b/spec/mailman/receiver/imap_spec.rb
@@ -54,9 +54,27 @@ describe Mailman::Receiver::IMAP do
       @receiver.get_messages
     end
 
-    it 'should delete the messages after processing' do
+    it 'should delete the messages with delete flag after processing' do
+      receiver_options = @receiver_options
+      receiver_options[:done_flags] = [Net::IMAP::DELETED]
+      receiver = Mailman::Receiver::IMAP.new(receiver_options)
+      receiver.connect
+      receiver.get_messages
+      expect(receiver.connection.search('ALL')).to be_empty
+    end
+
+    it 'should mark the messages as seen after processing' do
       @receiver.get_messages
-      expect(@receiver.connection.search(:all)).to be_empty
+      expect(@receiver.connection.search('UNSEEN')).to be_empty
+    end
+
+    it 'should move the message from read folder to seen folder' do
+      receiver_options = @receiver_options
+      receiver_options[:move_seen] = true
+      receiver = Mailman::Receiver::IMAP.new(receiver_options)
+      receiver.connect
+      receiver.get_messages
+      expect(receiver.connection.search('ALL')).to be_empty
     end
 
   end


### PR DESCRIPTION
I have added a new feature to move seen messages to other folder(by setting :move_seen in imap config ), this can be extended to move any message to any folder.

I have also written the test cases for the same, and updated the previous buggy test case.

*testcase bug* 
The processed messages don't get deleted it just get marked as seen, its get deleted only if deleted flag is passed, so i have updated the test cases accordingly.  