### PR TITLE
Fix Mailman.config.rails_root option description

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -359,7 +359,7 @@ is set, Mailman will use Maildir watching as the receiver.
 ### Rails
 
 `Mailman.config.rails_root` is the location of the root of a Rails app to
-load the environment from. If this option is set to `nil`, Rails environment
+load the environment from. If this option is set to `false`, Rails environment
 loading will be disabled.
 
 **Default**: `'.'`


### PR DESCRIPTION
`Mailman.config.rails_root = nil` is the same as default value '.'. If you want disable rails loading you have to set the option in `false` value.

See:
[lib/mailman/configuration.rb#L56](https://github.com/mailman/mailman/blob/master/lib/mailman/configuration.rb#L56)
[lib/mailman/application.rb#L59](https://github.com/mailman/mailman/blob/master/lib/mailman/application.rb#L59)