### PR TITLE
Reset the try count per loop

### DIFF
--- a/lib/mailman/application.rb
+++ b/lib/mailman/application.rb
@@ -139,8 +139,8 @@ module Mailman
       end
       Mailman.logger.info(polling_msg)
 
-      tries ||= 5
       loop do
+        tries ||= 5
         begin
           connection.connect
           connection.get_messages


### PR DESCRIPTION
In the main `Mailman::Application#polling_loop` method, if an
error is raised in either `connection.connect` or
`connection.get_messages`, the critical section is retried `tries`
times. However, if configured to be polling, the `tries` variable
is not reset, so subsequent errors will cause endless retries.
This resets the `tries` variable at the start of the loop, thus
ensuring that there are only `tries` retries per poll.