### PR TITLE
Spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Bugfixes
 
 ## 0.5.4 (January 3, 2013)
 
-Bufixes
+Bugfixes
 
   - Fix multipart message matching
   - Fix Rails environment require

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -342,7 +342,7 @@ Mailman.config.pop3 = {
 
 `Mailman.config.poll_interval` is the duration in seconds to wait between
 checking for new messages on the server. It is currently only used by the
-POP3 reciever. If it is set to `0`, Mailman will do a one-time retrieval and
+POP3 receiver. If it is set to `0`, Mailman will do a one-time retrieval and
 then exit.
 
 **Default**: `60`

--- a/lib/mailman/receiver/http.rb
+++ b/lib/mailman/receiver/http.rb
@@ -96,7 +96,7 @@ module Mailman
       #      }
       class RawPostParser
         # @param [Hash] opts The parser's options
-        # @option opts [String] :part_name ('message') The name of the mulipart segment which will contain the email
+        # @option opts [String] :part_name ('message') The name of the multipart segment which will contain the email
         def initialize(opts = {})
           @opts = opts
           @opts['part_name'] ||= 'message'

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -94,7 +94,7 @@ describe Mailman::Application do
     end
   end
 
-  it 'should poll a POP3 server, and process messsages' do
+  it 'should poll a POP3 server, and process messages' do
     config.pop3 = { :server => 'example.com',
                     :username => 'chunky',
                     :password => 'bacon' }
@@ -133,7 +133,7 @@ describe Mailman::Application do
     expect(@app.router.instance_variable_get('@count')).to be_nil
   end
 
-  it 'should poll an IMAP server, and process messsages' do
+  it 'should poll an IMAP server, and process messages' do
     config.imap = { :server => 'example.com',
                     :username => 'chunky',
                     :password => 'bacon' }

--- a/spec/functional/application_spec.rb
+++ b/spec/functional/application_spec.rb
@@ -214,7 +214,7 @@ describe Mailman::Application do
     end
   end
 
-  it 'should match a multipart endocoded body' do
+  it 'should match a multipart encoded body' do
     mailman_app {
       body /ID (\d+) (OK|NO)/ do
         raise "Captures Unavailable" unless params[:captures].first == '43'

--- a/spec/mailman/application_spec.rb
+++ b/spec/mailman/application_spec.rb
@@ -29,11 +29,11 @@ describe Mailman::Application do
           @app = Mailman::Application.new({poll_interval: 10}) {}
         end
 
-        it "should instanciate the configuration" do
+        it "should instantiate the configuration" do
           expect(@app.config).to be_a(Mailman::Configuration)
         end
 
-        it "should instanciate a config instance with params" do
+        it "should instantiate a config instance with params" do
           expect(@app.config.poll_interval).to eq(10)
         end
 
@@ -49,11 +49,11 @@ describe Mailman::Application do
           @app = Mailman::Application.new(@config) {}
         end
 
-        it "should instanciate the configuration" do
+        it "should instantiate the configuration" do
           expect(@app.config).to be_a(Mailman::Configuration)
         end
 
-        it "should instanciate a config instance with params" do
+        it "should instantiate a config instance with params" do
           expect(@app.config.poll_interval).to eq(10)
         end
 

--- a/spec/mailman/configuration_spec.rb
+++ b/spec/mailman/configuration_spec.rb
@@ -38,7 +38,7 @@ describe Mailman::Configuration do
     expect(config.maildir).to eq('../maildir-test')
   end
 
-  it 'should have a defaut watch maildir setting' do
+  it 'should have a default watch maildir setting' do
     expect(config.watch_maildir).to eq(true)
   end
 

--- a/spec/mailman/message_processor_spec.rb
+++ b/spec/mailman/message_processor_spec.rb
@@ -48,7 +48,7 @@ describe Mailman::MessageProcessor do
       expect(maildir_message.dir).to_not eq(:cur)
     end
 
-    it 'should log errors caused by processing the message, but not raise them so futher messages can be processed' do
+    it 'should log errors caused by processing the message, but not raise them so further messages can be processed' do
       error = StandardError.new('testing')
       expect(router).to receive(:route).with(basic_email).and_raise(error)
       expect(Mailman.logger).to receive(:error)


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`