### PR TITLE
Update Travis Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ cache: bundler
 sudo: false
 
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - 2.1.1
-  - 2.2.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - jruby-19mode
   - jruby-head
   - rbx-2


### PR DESCRIPTION
Remove the following unsupported Rubies from the Travis config:

* 1.9.3
* 2.0.0
* 2.1.1

Updated the following supported Ruby in the Travis config:

* 2.2.9

Add the following supported Rubies to the Travis config:

* 2.3.6
* 2.4.3
* 2.5.0